### PR TITLE
Update dependencies for Laravel 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 7.1
+#  - 7.1
   - 7.2
   - 7.3
   - 7.4snapshot

--- a/composer.json
+++ b/composer.json
@@ -18,16 +18,16 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.2.5",
         "pragmarx/ia-collection": ">=5.5.33",
         "pragmarx/ia-str": ">=5.5.33",
         "pragmarx/ia-arr": ">=5.5.33"
     },
     "require-dev": {
-        "mockery/mockery": "~1.0",
+        "mockery/mockery": "^1.3.1",
         "phpunit/php-timer": ">=1.0|>=2.0",
-        "phpunit/phpunit": ">=6.0|>=7.0",
-        "squizlabs/php_codesniffer": "^2.3"
+        "phpunit/phpunit": "^8.5",
+        "squizlabs/php_codesniffer": "^3.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Updated dependencies for Laravel 7.

## Description
Removed PHP 7.1 from travis.yml as Laravel 7 uses PHP 7.2.5
Updated dependencies to newer versions as Laravel 7 uses newer versions of `phpunit`, `carbon`, etc.